### PR TITLE
Fix a typo when setting a GSL environment variable

### DIFF
--- a/build_support.sh
+++ b/build_support.sh
@@ -355,7 +355,7 @@ dobuild()
         echo "GSL lib dir is $GSLLIB..."
         echo "GSL inc dir is $GSLINC..."
         echo "export GSLLIB=$GSLLIB" >> $ENVFILE
-        echo "export GSLINC=$GSLLINC" >> $ENVFILE
+        echo "export GSLINC=$GSLINC" >> $ENVFILE
         echo "export LD_LIBRARY_PATH=${GSLLIB}:\$LD_LIBRARY_PATH" >> $ENVFILE
     fi
 


### PR DESCRIPTION
Previous version does not correctly set GSL include path in environment setup file.